### PR TITLE
Shutdown stan connection on close

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,11 @@ function hemeraNatsStreaming(hemera, opts, done) {
 
   function onClose(hemera, done) {
     hemera.log.debug('nats-streaming closing ...')
+    stan.once('close', () => {
+      hemera.log.debug('nats-streaming nats connection closed')
+      done()
+    })
     stan.close()
-    hemera.log.debug('nats-streaming nats connection closed')
-    done()
   }
 
   function onError(err) {

--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ function hemeraNatsStreaming(hemera, opts, done) {
 
   function onClose(hemera, done) {
     hemera.log.debug('nats-streaming closing ...')
+    stan.close()
+    hemera.log.debug('nats-streaming nats connection closed')
     done()
   }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "hemera-plugin": "^1.3.0",
-    "node-nats-streaming": "^0.0.28"
+    "node-nats-streaming": "^0.0.41"
   },
   "devDependencies": {
     "code": "^3.0.2",

--- a/test/shutdown.js
+++ b/test/shutdown.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const Hemera = require('nats-hemera')
+const Nats = require('nats')
+const NatsStreaming = require('node-nats-streaming')
+const HemeraNatsStreaming = require('./../')
+const Code = require('code')
+const HemeraTestsuite = require('hemera-testsuite')
+const ssc = require('./support/stan_server_control')
+
+const os = require('os')
+const path = require('path')
+const nuid = require('nuid')
+const timers = require('timers')
+
+const expect = Code.expect
+
+describe('Hemera-nats-streaming graceful shutdown', function() {
+  let PORT = 4222
+  let clusterId = 'test-cluster'
+  let clientId = 'test-client'
+  let uri = 'nats://localhost:' + PORT
+  const topic = 'natss'
+  let server
+  let hemera
+  let natssInstance
+
+  let serverDir = path.join(os.tmpdir(), nuid.next())
+
+  before(function(done) {
+    server = ssc.start_server(
+      PORT,
+      ['--store', 'FILE', '--dir', serverDir],
+      function() {
+        // wait until server is ready
+        timers.setTimeout(function() {
+          const nats = Nats.connect()
+          natssInstance = NatsStreaming.connect(clusterId, clientId)
+          hemera = new Hemera(nats, {
+            logLevel: 'error'
+          })
+          hemera.use(HemeraNatsStreaming, {
+            natssInstance
+          })
+          hemera.ready(() => hemera.transport.flush(done))
+        }, 250)
+      }
+    )
+  })
+
+  after(function() {
+    server.kill()
+  })
+
+  it('Should close the connection', function(done) {
+    hemera.close(() => {
+      expect(natssInstance.isClosed()).to.be.equals(true)
+    done()
+    })
+  })
+})

--- a/test/shutdown.js
+++ b/test/shutdown.js
@@ -5,7 +5,6 @@ const Nats = require('nats')
 const NatsStreaming = require('node-nats-streaming')
 const HemeraNatsStreaming = require('./../')
 const Code = require('code')
-const HemeraTestsuite = require('hemera-testsuite')
 const ssc = require('./support/stan_server_control')
 
 const os = require('os')
@@ -35,7 +34,10 @@ describe('Hemera-nats-streaming graceful shutdown', function() {
         // wait until server is ready
         timers.setTimeout(function() {
           const nats = Nats.connect()
-          natssInstance = NatsStreaming.connect(clusterId, clientId)
+          natssInstance = NatsStreaming.connect(
+            clusterId,
+            clientId
+          )
           hemera = new Hemera(nats, {
             logLevel: 'error'
           })
@@ -55,7 +57,7 @@ describe('Hemera-nats-streaming graceful shutdown', function() {
   it('Should close the connection', function(done) {
     hemera.close(() => {
       expect(natssInstance.isClosed()).to.be.equals(true)
-    done()
+      done()
     })
   })
 })


### PR DESCRIPTION
Fixes #3 .

I tried to run the tests but I'm having some issues (both on Win10 Powershell and WSL). I'm also not sure if we can add some specific test case.

AFAIK there is currently no way to provide a callback to `stan.close()` nor wait for a Promise to resolve, therefore if the close is asynchronous, there is no way to wait for the completion.